### PR TITLE
Dev-reverse-proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,4 @@ module proxyserver/main
 
 go 1.21.3
 
-require rsc.io/quote v1.5.2
-
-require (
-	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
-	rsc.io/sampler v1.3.0 // indirect
-)
+require golang.org/x/time v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
-golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
-rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
-rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
-rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+golang.org/x/time v0.4.0 h1:Z81tqI5ddIoXDPvVQ7/7CC9TnLM7ubaFG2qXYd5BbYY=
+golang.org/x/time v0.4.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/src/main.go
+++ b/src/main.go
@@ -26,6 +26,15 @@ func main() {
 		// logging request
 		fmt.Printf("[reverse proxy server] received request at: %s\n", time.Now())
 
+		// setting request to point to origin server
+		request.Host = originServerURL.Host
+		request.URL.Host = originServerURL.Host
+		request.URL.Scheme = originServerURL.Scheme
+		request.RequestURI = ""
+
+		// send request to the origin server and save
+		originServerResponse, err := http.DefaultClient.Do(request)
+
 	})
 
 }

--- a/src/main.go
+++ b/src/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -41,6 +42,11 @@ func main() {
 			_, _ = fmt.Fprint(response_writer, err)
 			return
 		}
+
+		// return response to the client
+		response_writer.WriteHeader(http.StatusOK)
+		io.Copy(response_writer, originServerResponse.Body)
+
 	})
 
 }

--- a/src/main.go
+++ b/src/main.go
@@ -64,5 +64,4 @@ func main() {
 
 	// binding reverse-proxy to port
 	log.Fatal(http.ListenAndServe(":"+os.Getenv("REV_PROXY_PORT"), reverseProxy))
-
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
+	"time"
 )
 
 func main() {
@@ -17,5 +20,12 @@ func main() {
 	if err != nil {
 		log.Fatal("Error, invalid URL")
 	}
+
+	reverseProxy := http.HandlerFunc(func(response_writer http.ResponseWriter, request *http.Request) {
+
+		// logging request
+		fmt.Printf("[reverse proxy server] received request at: %s\n", time.Now())
+
+	})
 
 }

--- a/src/main.go
+++ b/src/main.go
@@ -62,4 +62,7 @@ func main() {
 
 	})
 
+	// binding reverse-proxy to port
+	log.Fatal(http.ListenAndServe(":"+os.Getenv("REV_PROXY_PORT"), reverseProxy))
+
 }

--- a/src/main.go
+++ b/src/main.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// hard coded for clarity
+// avg 1 request per second; max 3 requests per burst
 var limiter = rate.NewLimiter(1, 3)
 
 func main() {

--- a/src/main.go
+++ b/src/main.go
@@ -26,6 +26,7 @@ func main() {
 		log.Fatal("Error, invalid URL")
 	}
 
+	// reverse proxy handler object
 	reverseProxy := http.HandlerFunc(func(response_writer http.ResponseWriter, request *http.Request) {
 
 		// ensuring concurrent calls are within threshold
@@ -62,6 +63,6 @@ func main() {
 
 	})
 
-	// binding reverse-proxy to port
+	// binding reverse-proxy to desired port
 	log.Fatal(http.ListenAndServe(":"+os.Getenv("REV_PROXY_PORT"), reverseProxy))
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"fmt"
-
-	"rsc.io/quote"
+	"os"
 )
 
 func main() {
-	fmt.Println("Hello, World!")
-	fmt.Println(quote.Go())
+
+	// explicitly setting env vars (omit if already done)
+	os.Setenv("REV_PROXY_PORT", "8080")
+	os.Setenv("ORIGIN_URL", "http://127.0.0.1:8081")
+
 }

--- a/src/main.go
+++ b/src/main.go
@@ -35,6 +35,12 @@ func main() {
 		// send request to the origin server and save
 		originServerResponse, err := http.DefaultClient.Do(request)
 
+		// catch error with response and logging
+		if err != nil {
+			response_writer.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(response_writer, err)
+			return
+		}
 	})
 
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+	"net/url"
 	"os"
 )
 
@@ -9,5 +11,11 @@ func main() {
 	// explicitly setting env vars (omit if already done)
 	os.Setenv("REV_PROXY_PORT", "8080")
 	os.Setenv("ORIGIN_URL", "http://127.0.0.1:8081")
+
+	// retrieve origin server URL
+	originServerURL, err := url.Parse(os.Getenv("ORIGIN_URL"))
+	if err != nil {
+		log.Fatal("Error, invalid URL")
+	}
 
 }


### PR DESCRIPTION
This PR adds the following functionality for the reverse proxy server:

- The request-forwarding from client to origin server
- Rate limiting to ensure only minimum 1 request allowed per second in a burst of 3
- Forwarding the origin-response back to the user
- Error handling in case any above step goes wrong

In addition, this PR manages minor dependencies and adds comments to improve code readability

The reverse-proxy can now act as a middleware for users when accessing the origin server and performs the rate-limiting as intended